### PR TITLE
added dfs by modifying bfs-counter

### DIFF
--- a/src/search.py
+++ b/src/search.py
@@ -49,7 +49,6 @@ class SearchNode:
 def dfs(problem: SearchProblem) -> Optional[Solution]:
     stack = PriorityQueue()
     initialState = problem.initial_state # first State of (sub)-tree
-    #print("intialState: ", initialState)
     root = SearchNode(initialState, None, None)
     visitedStates = set()
     
@@ -59,7 +58,6 @@ def dfs(problem: SearchProblem) -> Optional[Solution]:
 
     while not(stack.is_empty()):
         parentNode = stack.pop()
-        #print("chosen node: ", parentNode)
         parentState = parentNode.state
 
         if problem.is_goal_state(parentState):
@@ -70,7 +68,6 @@ def dfs(problem: SearchProblem) -> Optional[Solution]:
         for child in reversed(childrenStates): # for left-to-right traversal
             stack.count += 1
             childNode = SearchNode(child[0], parentNode, child[1])
-            #print("updated Prio: ", queue.count)
             if not(childNode in visitedStates):
                 stack.push(childNode, -stack.count) # makes it so that most recent node gets popped => LIFO
                 visitedStates.add(childNode)
@@ -88,7 +85,6 @@ def dfs(problem: SearchProblem) -> Optional[Solution]:
 def bfs(problem: SearchProblem) -> Optional[Solution]:
     queue = PriorityQueue()
     initialState = problem.initial_state # first State of (sub)-tree
-    #print("intialState: ", initialState)
     root = SearchNode(initialState, None, None)
     visitedStates = set()
     
@@ -98,7 +94,6 @@ def bfs(problem: SearchProblem) -> Optional[Solution]:
 
     while not(queue.is_empty()):
         parentNode = queue.pop()
-        #print("chosen node: ", parentNode)
         parentState = parentNode.state
 
         if problem.is_goal_state(parentState):
@@ -109,7 +104,6 @@ def bfs(problem: SearchProblem) -> Optional[Solution]:
         for child in childrenStates:
             queue.count += 1
             childNode = SearchNode(child[0], parentNode, child[1])
-            #print("updated Prio: ", queue.count)
             if not(childNode in visitedStates):
                 queue.push(childNode, queue.count)
                 visitedStates.add(childNode)


### PR DESCRIPTION
DFS works JUST like bfs, aside from the way that the priorities are assigned.
By pushing the first node, getting successors and giving following successors `-counter`-priorities, we simulate LIFO-behavior.
The latest pushed node is always the one getting popped next.
By also reversing the childList, we ensure right-to-left traversal of the tree, otherwise it should still be valid.